### PR TITLE
Flatten API

### DIFF
--- a/miqa/core/rest/experiment.py
+++ b/miqa/core/rest/experiment.py
@@ -1,7 +1,7 @@
+from django_filters import rest_framework as filters
 from rest_framework import serializers
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ReadOnlyModelViewSet
-from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from miqa.core.models import Experiment
 from miqa.core.rest.session import SessionSerializer
@@ -15,8 +15,11 @@ class ExperimentSerializer(serializers.ModelSerializer):
     session = SessionSerializer()
 
 
-class ExperimentViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
+class ExperimentViewSet(ReadOnlyModelViewSet):
     queryset = Experiment.objects.all()
+
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_fields = ['session']
 
     permission_classes = [AllowAny]
     serializer_class = ExperimentSerializer

--- a/miqa/core/rest/image.py
+++ b/miqa/core/rest/image.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from django.http import FileResponse, HttpResponseServerError
+from django_filters import rest_framework as filters
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import GenericViewSet
-from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from miqa.core.models import Image
 
@@ -17,8 +17,11 @@ class ImageSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'scan']
 
 
-class ImageViewSet(NestedViewSetMixin, ListModelMixin, GenericViewSet):
+class ImageViewSet(ListModelMixin, GenericViewSet):
     queryset = Image.objects.all()
+
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_fields = ['scan']
 
     permission_classes = [AllowAny]
     serializer_class = ImageSerializer

--- a/miqa/core/rest/scan.py
+++ b/miqa/core/rest/scan.py
@@ -1,7 +1,7 @@
+from django_filters import rest_framework as filters
 from rest_framework import serializers
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ReadOnlyModelViewSet
-from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from miqa.core.models import Scan
 
@@ -14,8 +14,11 @@ class ScanSerializer(serializers.ModelSerializer):
     decision = serializers.ChoiceField(choices=Scan.decision.field.choices)
 
 
-class ScanViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
+class ScanViewSet(ReadOnlyModelViewSet):
     queryset = Scan.objects.all()
+
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_fields = ['experiment', 'site']
 
     permission_classes = [AllowAny]
     serializer_class = ScanSerializer

--- a/miqa/core/rest/site.py
+++ b/miqa/core/rest/site.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from rest_framework import serializers
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -13,6 +14,9 @@ class SiteSerializer(serializers.ModelSerializer):
 
 class SiteViewSet(ReadOnlyModelViewSet):
     queryset = Site.objects.all()
+
+    filter_backends = [filters.DjangoFilterBackend]
+    filterset_fields = ['session']
 
     permission_classes = [AllowAny]
     serializer_class = SiteSerializer

--- a/miqa/urls.py
+++ b/miqa/urls.py
@@ -3,35 +3,16 @@ from django.contrib import admin
 from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
-from rest_framework import permissions
-from rest_framework_extensions.routers import ExtendedSimpleRouter
+from rest_framework import permissions, routers
 
 from miqa.core.rest import ExperimentViewSet, ImageViewSet, ScanViewSet, SessionViewSet, SiteViewSet
 
-router = ExtendedSimpleRouter(trailing_slash=False)
-session_router = router.register('sessions', SessionViewSet, basename='session')
-session_router.register(
-    'experiments',
-    ExperimentViewSet,
-    basename='experiment',
-    parents_query_lookups=['session__id'],
-).register(
-    'scans',
-    ScanViewSet,
-    basename='scan',
-    parents_query_lookups=['experiment__session__id', 'experiment__id'],
-).register(
-    'images',
-    ImageViewSet,
-    basename='image',
-    parents_query_lookups=['scan__experiment__session__id', 'scan__experiment__id', 'scan__id'],
-)
-session_router.register(
-    'sites',
-    SiteViewSet,
-    basename='site',
-    parents_query_lookups=['session__id'],
-)
+router = routers.SimpleRouter(trailing_slash=False)
+router.register('sessions', SessionViewSet, basename='session')
+router.register('experiments', ExperimentViewSet)
+router.register('scans', ScanViewSet)
+router.register('images', ImageViewSet)
+router.register('sites', SiteViewSet)
 
 # OpenAPI generation
 schema_view = get_schema_view(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'django-oauth-toolkit',
         'djangorestframework',
         'drf-yasg',
-        'drf-extensions',
         # Production-only
         'django-composed-configuration[prod]',
         'django-s3-file-field[boto3]',


### PR DESCRIPTION
* Remove `NestedViewSetMixin` from all viewsets
* Add parent filters to all viewsets
* Flatten the API so that all models have a top level resource
* Remove `drf-extensions` as it was only used for the nested routing